### PR TITLE
fixed wrong colour escapes and terminal refresh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -44,7 +44,11 @@ EOL
 fi
 
 source $HOME/.brew_fix.zsh
-echo "\033[0;31mbrew update might take some time, please be patient\0[0m"
+echo "\033[0;31mbrew update might take some time, please be patient\033[0m"
 brew update
 brew upgrade
-echo "\033[0;32mPlease open a new terminal to apply modifications\0[0m"
+. ~/.zshrc
+source ~/.zshrc
+echo "\033[0;32mHomebrew is now ready. Run brew --help to see homebrew options.\033[0m"
+
+


### PR DESCRIPTION
Colour reset in bash is supposed to be "\033[0m" not "\0[0m" on lines 47. Also added zshrc source command to the end to automatically re-run zshrc so the user doesn't have to close and re-open their terminal.